### PR TITLE
[DM-29923] Document Cookie and Authorization stripping

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -101,7 +101,7 @@ Disadvantages:
   This includes any request to a backend service that uses Gafaelfawr's OpenID Connect support instead.
   This could be mitigated by supporting a stripped-down ``auth_request`` handler mode that only cleans the headers and sending all requests, even unauthenticated requests, through an ``auth_request`` handler, at the cost of additional complexity and possible fragility.
 - This adds additional complexity to the required ingress configuration to use Gafaelfawr, which is already very complex.
-  If we take this approach, it may be worth adding Gafaelfawr support for a custom ingress resource and have Gafaelfawr add the appropriate annotations and generate the real ``Ingress` resource from that custom resource.
+  If we take this approach, it may be worth adding Gafaelfawr support for a custom ingress resource and have Gafaelfawr add the appropriate annotations and generate the real ``Ingress`` resource from that custom resource.
 - Does not isolate the JavaScript of each service.
   All services are still in the same JavaScript origin, which means that malicious JavaScript injected into any service could still make authenticated requests to other services, even though the attacker would not have direct access to the cookie.
 

--- a/index.rst
+++ b/index.rst
@@ -9,6 +9,10 @@ The current design for authentication for the Rubin Science Platform leaks cooki
 This undermines isolation between services, which could become relevant if a service is compromised.
 This document proposes several possible alternative designs, including one that uses separate hostnames for each Rubin Science Platform service, and discusses the complexity and effort trade-offs.
 
+See `DMTN-193`_ for a more general discussion of web security for the Science Platform.
+
+.. _DMTN-193: https://dmtn-193.lsst.io/
+
 Background
 ==========
 

--- a/index.rst
+++ b/index.rst
@@ -75,7 +75,7 @@ Replace ``Cookie`` and ``Authorization`` headers
 ------------------------------------------------
 
 While the ``auth_request`` handler cannot remove headers, NGINX and the Kubernetes ``Ingress`` annotations do provide a way of replacing headers in the request with headers returned by the ``auth_request`` handler before passing them to the backend.
-We could make use of this by having Gafaelfawr return a ``Cookie`` header that is the same as the incoming request but Gafaelfawr cookie stripped out of it, and then configure the ingress to replace the incoming header with that header via:
+We could make use of this by having Gafaelfawr return a ``Cookie`` header that is the same as the incoming request but with the Gafaelfawr cookie stripped out of it, and then configure the ingress to replace the incoming header with that header via:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
A discussion with other security folks uncovered the possibility of
returning stripped Cookie and Authorization headers from the
auth_request handler and lifting them up into the request as an
alternative to doing complex things in NGINX configuration.  Document
that and recommended it as the best approach.

Link to DMTN-076 even though it isn't published yet.

Use nb.data.lsst.cloud instead of notebook.data.lsst.cloud to follow
our naming conventions.